### PR TITLE
fixes #11 added ViewModel for CardPicker

### DIFF
--- a/PlanningPoker.xcodeproj/project.pbxproj
+++ b/PlanningPoker.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		E7A838A723DA341B007DCD19 /* PokerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A838A623DA341B007DCD19 /* PokerService.swift */; };
 		E7A838AA23DA36EB007DCD19 /* MockDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A838A923DA36EB007DCD19 /* MockDependencies.swift */; };
 		E7A838AC23DA3747007DCD19 /* MockPokerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A838AB23DA3747007DCD19 /* MockPokerService.swift */; };
+		E7A838B023DA79E4007DCD19 /* CardPickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A838AF23DA79E4007DCD19 /* CardPickerViewModel.swift */; };
 		FB1B038A23C3E80300E2EE34 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1B038923C3E80300E2EE34 /* AppDelegate.swift */; };
 		FB1B039123C3E80500E2EE34 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FB1B039023C3E80500E2EE34 /* Assets.xcassets */; };
 		FB1B039423C3E80500E2EE34 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FB1B039223C3E80500E2EE34 /* LaunchScreen.storyboard */; };
@@ -56,6 +57,7 @@
 		E7A838A623DA341B007DCD19 /* PokerService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokerService.swift; sourceTree = "<group>"; };
 		E7A838A923DA36EB007DCD19 /* MockDependencies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDependencies.swift; sourceTree = "<group>"; };
 		E7A838AB23DA3747007DCD19 /* MockPokerService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPokerService.swift; sourceTree = "<group>"; };
+		E7A838AF23DA79E4007DCD19 /* CardPickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPickerViewModel.swift; sourceTree = "<group>"; };
 		FB1B038623C3E80300E2EE34 /* PlanningPoker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PlanningPoker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FB1B038923C3E80300E2EE34 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		FB1B039023C3E80500E2EE34 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -204,6 +206,7 @@
 		FBA7D59D23CD162B003C60C0 /* Poker */ = {
 			isa = PBXGroup;
 			children = (
+				E7A838AF23DA79E4007DCD19 /* CardPickerViewModel.swift */,
 				FBA7D59F23CD162B003C60C0 /* CardPickerViewController.swift */,
 				E7A8388D23D7B55D007DCD19 /* CardCellView.swift */,
 				E75E283423D781A300DC14EC /* Card.swift */,
@@ -321,6 +324,7 @@
 				FBA7D5A123CD162B003C60C0 /* CardDetailViewController.swift in Sources */,
 				E7A8389323D923B0007DCD19 /* AppCoordinator.swift in Sources */,
 				E7A8388E23D7B55D007DCD19 /* CardCellView.swift in Sources */,
+				E7A838B023DA79E4007DCD19 /* CardPickerViewModel.swift in Sources */,
 				E75E282F23D76E4C00DC14EC /* MenuViewController.swift in Sources */,
 				E7A838A523DA33DF007DCD19 /* Depencencies.swift in Sources */,
 				E7A838A723DA341B007DCD19 /* PokerService.swift in Sources */,

--- a/PlanningPoker/Source/Features/Poker/CardPickerViewModel.swift
+++ b/PlanningPoker/Source/Features/Poker/CardPickerViewModel.swift
@@ -1,0 +1,91 @@
+//
+//  CardPickerViewModel.swift
+//  PlanningPoker
+//
+//  Created by George Webster on 1/23/20.
+//  Copyright © 2020 George Webster. All rights reserved.
+//
+
+import Foundation
+
+class CardPickerViewModel {
+    
+    typealias LocalDependencies = CardLoadingProvider
+    private let service: CardLoading
+
+    private(set) var state: State {
+        didSet { onStateChanged(state) }
+    }
+    
+    var onStateChanged: (State) -> Void = { _ in }
+    
+    init(with dependencies: LocalDependencies) {
+        self.service = dependencies.cardLoadingService
+        self.state = State(with: .normal)
+    }
+    
+    //MARK:- Actions
+    
+    func loadCards() {
+        state.mode = .loading
+        service.loadCards { [weak self] (result) in
+            switch result {
+            case .success(let cards):
+                self?.state = State(with: cards)
+            case .failure(let error):
+                self?.state.mode = .error(error)
+            }
+        }
+    }
+    
+    func didSelectedCard(at index: Int) {
+        guard let card = state.card(at:index) else {
+            return //TODO: should this be an error?
+        }
+        state.mode = .selected(card)
+    }
+
+}
+
+extension CardPickerViewModel {
+    
+    struct State {
+
+        var mode: DisplayMode
+        
+        private var cards: [Card] = []
+        
+        
+        var numberOfCards: Int { cards.count }
+        
+        func card(at index: Int) -> Card? {
+            cards[index]
+        }
+    }
+    
+}
+
+extension CardPickerViewModel.State {
+    
+    init(with mode: CardPickerViewModel.DisplayMode) {
+        self.mode = mode
+        self.cards = []
+    }
+
+    init(with cards:[Card]) {
+        self.mode = .normal
+        self.cards = cards
+    }
+}
+
+extension CardPickerViewModel {
+    
+    enum DisplayMode {
+
+        case normal
+        case loading
+        case error(Error)
+        case selected(Card)
+    }
+}
+

--- a/PlanningPokerTests/CardPickerTests.swift
+++ b/PlanningPokerTests/CardPickerTests.swift
@@ -9,7 +9,11 @@
 import XCTest
 @testable import PlanningPoker
 
-class CardPickerTests: XCTestCase {
+class CardPickerTests: XCTestCase {}
+
+//MARK:- View Tests
+
+extension CardPickerTests {
 
     func testCardsLoad() {
         
@@ -22,11 +26,11 @@ class CardPickerTests: XCTestCase {
         let sut = CardPickerViewController(with: dependencies)
         _ = sut.view
 
-        XCTAssert(sut.cards.count == 0)
+        XCTAssert(sut.collectionView.numberOfItems(inSection: 0) == 0)
 
         wait(for: [exp], timeout: 10)
-        
-        XCTAssert(sut.cards.count > 0)
+
+        XCTAssert(sut.collectionView.numberOfItems(inSection: 0) > 0)
     }
 
     func testCardsLoad_failure() {
@@ -40,9 +44,98 @@ class CardPickerTests: XCTestCase {
         let sut = CardPickerViewController(with: dependencies)
         _ = sut.view
 
-        XCTAssert(sut.cards.count == 0)
+        XCTAssert(sut.collectionView.numberOfItems(inSection: 0) == 0)
         wait(for: [exp], timeout: 10)
-        XCTAssert(sut.cards.count == 0)
+        XCTAssert(sut.collectionView.numberOfItems(inSection: 0) == 0)
     }
+
+}
+
+
+//MARK:- ViewModel Tests
+
+extension CardPickerTests {
+
+    func testDefaults() {
+        
+        let dependencies = MockDependencies()
+        let sut = CardPickerViewModel(with: dependencies)
+        switch sut.state.mode {
+        case .normal: break//pass
+        default: XCTFail()
+        }
+        XCTAssert(sut.state.numberOfCards == 0)
+    }
+    
+    func testLoadCards_failure() {
+        let exp = expectation(description: "loading")
+        let dependencies = MockDependencies()
+        dependencies.pokerService.result = .failure(MockError.networkError)
+        dependencies.pokerService.onComplete = { _ in
+            exp.fulfill()
+        }
+        let sut = CardPickerViewModel(with: dependencies)
+        sut.loadCards()
+        
+        switch sut.state.mode {
+        case .loading: break//pass
+        default: XCTFail()
+        }
+
+        wait(for: [exp], timeout: 10)
+        
+        switch sut.state.mode {
+        case .error: break//pass
+        default: XCTFail()
+        }
+        XCTAssert(sut.state.numberOfCards == 0)
+    }
+
+    func testLoadCards_success() {
+        let exp = expectation(description: "loading")
+        let dependencies = MockDependencies()
+        dependencies.pokerService.result = .success(Card.allCases)
+        dependencies.pokerService.onComplete = { _ in
+            exp.fulfill()
+        }
+        let sut = CardPickerViewModel(with: dependencies)
+        sut.loadCards()
+        
+        switch sut.state.mode {
+        case .loading: break//pass
+        default: XCTFail()
+        }
+
+        wait(for: [exp], timeout: 10)
+        
+        switch sut.state.mode {
+        case .normal: break//pass
+        default: XCTFail()
+        }
+        XCTAssert(sut.state.numberOfCards == Card.allCases.count)
+    }
+    
+    func testSelectCard() {
+        
+        let exp = expectation(description: "loading")
+        let dependencies = MockDependencies()
+        dependencies.pokerService.result = .success(Card.allCases)
+        dependencies.pokerService.onComplete = { _ in
+            exp.fulfill()
+        }
+
+        let sut = CardPickerViewModel(with: dependencies)
+        sut.loadCards()
+        wait(for: [exp], timeout: 10)
+
+        sut.didSelectedCard(at: 0)
+        switch sut.state.mode {
+        case .selected(let card):
+            XCTAssert(card.description == Card.allCases[0].description)
+        default: XCTFail()
+        }
+
+    }
+
 
 }


### PR DESCRIPTION
businsess logic and model access lifted into ViewModel
all updates piped through ViewModel’s state changed notifications
the view(controller) not reads like XML, this == that all asignment and user interaction responses.

updated tests accordingly